### PR TITLE
Add project scaffolding: Makefile, README, tests, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binary
+gum-keys
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary and coverage
+*.test
+*.out
+coverage.html
+
+# Dependency directories
+vendor/
+
+# IDE/editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: build install fmt clean test
+
+BINARY := gum-keys
+INSTALL_DIR := $(HOME)/.local/bin
+
+build:
+	go build -o $(BINARY) .
+
+install: build
+	@mkdir -p $(INSTALL_DIR)
+	cp $(BINARY) $(INSTALL_DIR)/
+
+fmt:
+	go fmt ./...
+
+test:
+	go test -v ./...
+
+clean:
+	rm -f $(BINARY)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# gum-keys
+
+A keyboard-driven menu TUI for quick actions. Define menus via YAML config or pipe items through stdin.
+
+Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) and [Lip Gloss](https://github.com/charmbracelet/lipgloss).
+
+## Installation
+
+```bash
+# Clone and build
+git clone https://github.com/cmarcotte/gum-keys.git
+cd gum-keys
+make build
+
+# Install to ~/.local/bin
+make install
+```
+
+## Usage
+
+### YAML Config
+
+```bash
+gum-keys --config menu.yaml
+```
+
+### Stdin (piped input)
+
+```bash
+# Format: key:label or key:label:value
+echo -e "a:Apple\nb:Banana\nc:Cherry" | gum-keys
+```
+
+### Override title
+
+```bash
+gum-keys --config menu.yaml --title "My Menu"
+```
+
+## Configuration
+
+### Example YAML
+
+```yaml
+title: "Quick Actions"
+
+style:
+  key: "#f5a97f"       # Key color (hex or ANSI 256)
+  label: "#cad3f5"     # Label color
+  title: "#c6a0f6"     # Title color
+  submenu: "#eed49f"   # Submenu indicator color
+  separator: "#6e738d" # Separator color
+  border: "rounded"    # rounded, double, thick, normal, hidden
+
+items:
+  - name: "Open Editor"
+    key: e
+    command: "nvim ."
+
+  - name: "+Git"
+    key: g
+    menu:
+      - name: Status
+        key: s
+        command: "git status"
+      - name: Lazygit
+        key: l
+        tmux: "new-window lazygit"
+
+  - separator: true
+
+  - name: "Select Me"
+    key: x
+    value: "custom-output"
+```
+
+### Item Fields
+
+| Field       | Description                              |
+|-------------|------------------------------------------|
+| `name`      | Display label                            |
+| `key`       | Key trigger (single character)           |
+| `command`   | Shell command to execute                 |
+| `tmux`      | Tmux command (runs as `tmux <command>`)  |
+| `value`     | Output value (printed to stdout)         |
+| `menu`      | Nested submenu items                     |
+| `separator` | If `true`, renders as a separator line   |
+| `transient` | If `true`, menu stays open after select  |
+
+### Style Options
+
+| Field       | Values                                        |
+|-------------|-----------------------------------------------|
+| `key`       | Hex color (`#f5a97f`) or ANSI 256 (`212`)     |
+| `label`     | Hex color or ANSI 256                         |
+| `title`     | Hex color or ANSI 256                         |
+| `submenu`   | Hex color or ANSI 256                         |
+| `separator` | Hex color or ANSI 256                         |
+| `border`    | `rounded`, `double`, `thick`, `normal`, `hidden` |
+
+## Keybindings
+
+| Key       | Action                    |
+|-----------|---------------------------|
+| `[key]`   | Activate menu item        |
+| `Esc`     | Back / quit               |
+| `q`       | Quit (at root menu)       |
+| `Ctrl+C`  | Quit immediately          |
+
+## License
+
+MIT

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 
@@ -51,10 +52,10 @@ func LoadConfig(path string) (Config, error) {
 	return config, err
 }
 
-// ParseStdin parses menu items from stdin in format: key:label or key:label:value
-func ParseStdin() []Item {
+// ParseItems parses menu items from a reader in format: key:label or key:label:value
+func ParseItems(r io.Reader) []Item {
 	var items []Item
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -76,4 +77,9 @@ func ParseStdin() []Item {
 	}
 
 	return items
+}
+
+// ParseStdin parses menu items from stdin
+func ParseStdin() []Item {
+	return ParseItems(os.Stdin)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create temp YAML file
+	content := `title: "Test Menu"
+style:
+  key: "#ff0000"
+  border: "rounded"
+items:
+  - name: Item One
+    key: a
+    command: "echo one"
+  - name: Item Two
+    key: b
+    value: "two"
+  - separator: true
+  - name: "+Submenu"
+    key: s
+    menu:
+      - name: Nested
+        key: n
+        tmux: "new-window"
+`
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Verify title
+	if config.Title != "Test Menu" {
+		t.Errorf("expected title 'Test Menu', got %q", config.Title)
+	}
+
+	// Verify style
+	if config.Style.Key != "#ff0000" {
+		t.Errorf("expected style.key '#ff0000', got %q", config.Style.Key)
+	}
+	if config.Style.Border != "rounded" {
+		t.Errorf("expected style.border 'rounded', got %q", config.Style.Border)
+	}
+
+	// Verify items count (including separator)
+	if len(config.Items) != 4 {
+		t.Errorf("expected 4 items, got %d", len(config.Items))
+	}
+
+	// Verify first item
+	if config.Items[0].Name != "Item One" {
+		t.Errorf("expected first item name 'Item One', got %q", config.Items[0].Name)
+	}
+	if config.Items[0].Key != "a" {
+		t.Errorf("expected first item key 'a', got %q", config.Items[0].Key)
+	}
+	if config.Items[0].Command != "echo one" {
+		t.Errorf("expected first item command 'echo one', got %q", config.Items[0].Command)
+	}
+
+	// Verify value field
+	if config.Items[1].Value != "two" {
+		t.Errorf("expected second item value 'two', got %q", config.Items[1].Value)
+	}
+
+	// Verify separator
+	if !config.Items[2].Separator {
+		t.Error("expected third item to be separator")
+	}
+
+	// Verify submenu
+	if len(config.Items[3].Menu) != 1 {
+		t.Errorf("expected submenu with 1 item, got %d", len(config.Items[3].Menu))
+	}
+	if config.Items[3].Menu[0].Tmux != "new-window" {
+		t.Errorf("expected nested tmux 'new-window', got %q", config.Items[3].Menu[0].Tmux)
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(configPath, []byte("invalid: yaml: content: ["), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestParseItems(t *testing.T) {
+	input := `a:Apple
+b:Banana
+c:Cherry:cherry-value`
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+
+	// First item: key:label
+	if items[0].Key != "a" || items[0].Name != "Apple" {
+		t.Errorf("item 0: expected key='a' name='Apple', got key=%q name=%q", items[0].Key, items[0].Name)
+	}
+	if items[0].Value != "" {
+		t.Errorf("item 0: expected empty value, got %q", items[0].Value)
+	}
+
+	// Third item: key:label:value
+	if items[2].Key != "c" || items[2].Name != "Cherry" || items[2].Value != "cherry-value" {
+		t.Errorf("item 2: expected key='c' name='Cherry' value='cherry-value', got key=%q name=%q value=%q",
+			items[2].Key, items[2].Name, items[2].Value)
+	}
+}
+
+func TestParseItems_EmptyLines(t *testing.T) {
+	input := `a:Apple
+
+b:Banana
+
+`
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items (empty lines skipped), got %d", len(items))
+	}
+}
+
+func TestParseItems_Whitespace(t *testing.T) {
+	input := "  a  :  Apple  \n  b:Banana:  spaced value  "
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	if items[0].Key != "a" || items[0].Name != "Apple" {
+		t.Errorf("whitespace not trimmed: key=%q name=%q", items[0].Key, items[0].Name)
+	}
+
+	if items[1].Value != "spaced value" {
+		t.Errorf("value whitespace not trimmed: %q", items[1].Value)
+	}
+}
+
+func TestParseItems_InvalidLines(t *testing.T) {
+	input := `valid:Item
+invalid-no-colon
+also:valid`
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items (invalid line skipped), got %d", len(items))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `.gitignore` for binary and Go artifacts
- Add `Makefile` with `build`, `install`, `fmt`, `test`, `clean` targets
- Add `README.md` with installation, usage, and configuration reference
- Add `config_test.go` with 7 tests covering YAML and stdin parsing
- Refactor `ParseStdin` to `ParseItems(io.Reader)` for testability

## Test plan
- [x] `make build` compiles successfully
- [x] `make test` passes all 7 tests
- [x] `make fmt` formats code
- [ ] Verify `make install` copies binary to `~/.local/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)