### PR TITLE
Add TPM plugin support for tmux integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binary
+bin/
 gum-keys
 
 # Go build artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binary
+gum-keys
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary and coverage
+*.test
+*.out
+coverage.html
+
+# Dependency directories
+vendor/
+
+# IDE/editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
-.PHONY: build install fmt clean test
+.PHONY: build install uninstall fmt clean test
 
 BINARY := gum-keys
-INSTALL_DIR := $(HOME)/.local/bin
+BIN_DIR := bin
+PLUGIN_DIR := $(HOME)/.tmux/plugins/gum-keys
 
 build:
-	go build -o $(BINARY) .
+	@mkdir -p $(BIN_DIR)
+	go build -o $(BIN_DIR)/$(BINARY) .
 
 install: build
-	@mkdir -p $(INSTALL_DIR)
-	cp $(BINARY) $(INSTALL_DIR)/
+	@mkdir -p $(HOME)/.tmux/plugins
+	@ln -sfn $(PWD) $(PLUGIN_DIR)
+	@tmux run-shell $(PLUGIN_DIR)/gum-keys.tmux 2>/dev/null || true
+	@echo "Installed. Press prefix + Space to use."
+
+uninstall:
+	@rm -f $(PLUGIN_DIR)
+	@echo "Uninstalled."
 
 fmt:
 	go fmt ./...
@@ -17,4 +25,4 @@ test:
 	go test -v ./...
 
 clean:
-	rm -f $(BINARY)
+	rm -rf $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: build install fmt clean test
+
+BINARY := gum-keys
+INSTALL_DIR := $(HOME)/.local/bin
+
+build:
+	go build -o $(BINARY) .
+
+install: build
+	@mkdir -p $(INSTALL_DIR)
+	cp $(BINARY) $(INSTALL_DIR)/
+
+fmt:
+	go fmt ./...
+
+test:
+	go test -v ./...
+
+clean:
+	rm -f $(BINARY)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# gum-keys
+
+A keyboard-driven menu TUI for quick actions. Define menus via YAML config or pipe items through stdin.
+
+Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) and [Lip Gloss](https://github.com/charmbracelet/lipgloss).
+
+## Installation
+
+```bash
+# Clone and build
+git clone https://github.com/cmarcotte/gum-keys.git
+cd gum-keys
+make build
+
+# Install to ~/.local/bin
+make install
+```
+
+## Usage
+
+### YAML Config
+
+```bash
+gum-keys --config menu.yaml
+```
+
+### Stdin (piped input)
+
+```bash
+# Format: key:label or key:label:value
+echo -e "a:Apple\nb:Banana\nc:Cherry" | gum-keys
+```
+
+### Override title
+
+```bash
+gum-keys --config menu.yaml --title "My Menu"
+```
+
+## Configuration
+
+### Example YAML
+
+```yaml
+title: "Quick Actions"
+
+style:
+  key: "#f5a97f"       # Key color (hex or ANSI 256)
+  label: "#cad3f5"     # Label color
+  title: "#c6a0f6"     # Title color
+  submenu: "#eed49f"   # Submenu indicator color
+  separator: "#6e738d" # Separator color
+  border: "rounded"    # rounded, double, thick, normal, hidden
+
+items:
+  - name: "Open Editor"
+    key: e
+    command: "nvim ."
+
+  - name: "+Git"
+    key: g
+    menu:
+      - name: Status
+        key: s
+        command: "git status"
+      - name: Lazygit
+        key: l
+        tmux: "new-window lazygit"
+
+  - separator: true
+
+  - name: "Select Me"
+    key: x
+    value: "custom-output"
+```
+
+### Item Fields
+
+| Field       | Description                              |
+|-------------|------------------------------------------|
+| `name`      | Display label                            |
+| `key`       | Key trigger (single character)           |
+| `command`   | Shell command to execute                 |
+| `tmux`      | Tmux command (runs as `tmux <command>`)  |
+| `value`     | Output value (printed to stdout)         |
+| `menu`      | Nested submenu items                     |
+| `separator` | If `true`, renders as a separator line   |
+| `transient` | If `true`, menu stays open after select  |
+
+### Style Options
+
+| Field       | Values                                        |
+|-------------|-----------------------------------------------|
+| `key`       | Hex color (`#f5a97f`) or ANSI 256 (`212`)     |
+| `label`     | Hex color or ANSI 256                         |
+| `title`     | Hex color or ANSI 256                         |
+| `submenu`   | Hex color or ANSI 256                         |
+| `separator` | Hex color or ANSI 256                         |
+| `border`    | `rounded`, `double`, `thick`, `normal`, `hidden` |
+
+## Keybindings
+
+| Key       | Action                    |
+|-----------|---------------------------|
+| `[key]`   | Activate menu item        |
+| `Esc`     | Back / quit               |
+| `q`       | Quit (at root menu)       |
+| `Ctrl+C`  | Quit immediately          |
+
+## License
+
+MIT

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,12 +1,16 @@
 title: "gum-keys"
 
+layout:
+  max_width: 16   # Truncate labels longer than this
+  max_lines: 10   # Show this many items before scrolling
+
 style:
   key: "#f5a97f"       # Peach (catppuccin)
   label: "#cad3f5"     # Text
   title: "#c6a0f6"     # Mauve
   submenu: "#eed49f"   # Yellow
   separator: "#6e738d" # Overlay0
-  border: "rounded"
+  border: "hidden"
 
 items:
   - name: "+Windows"

--- a/config.go
+++ b/config.go
@@ -20,6 +20,12 @@ type Style struct {
 	Padding   string `yaml:"padding"`   // Padding inside box
 }
 
+// Layout defines size constraints
+type Layout struct {
+	MaxWidth int `yaml:"max_width"` // Max label width before truncation
+	MaxLines int `yaml:"max_lines"` // Max visible lines before scrolling
+}
+
 // Item represents a menu item
 type Item struct {
 	Name      string `yaml:"name"`      // Display label
@@ -34,9 +40,10 @@ type Item struct {
 
 // Config represents the full configuration
 type Config struct {
-	Title string `yaml:"title"`
-	Style Style  `yaml:"style"`
-	Items []Item `yaml:"items"`
+	Title  string `yaml:"title"`
+	Style  Style  `yaml:"style"`
+	Layout Layout `yaml:"layout"`
+	Items  []Item `yaml:"items"`
 }
 
 // LoadConfig loads configuration from a YAML file

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 
@@ -51,10 +52,10 @@ func LoadConfig(path string) (Config, error) {
 	return config, err
 }
 
-// ParseStdin parses menu items from stdin in format: key:label or key:label:value
-func ParseStdin() []Item {
+// ParseItems parses menu items from a reader in format: key:label or key:label:value
+func ParseItems(r io.Reader) []Item {
 	var items []Item
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -76,4 +77,9 @@ func ParseStdin() []Item {
 	}
 
 	return items
+}
+
+// ParseStdin parses menu items from stdin
+func ParseStdin() []Item {
+	return ParseItems(os.Stdin)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create temp YAML file
+	content := `title: "Test Menu"
+style:
+  key: "#ff0000"
+  border: "rounded"
+items:
+  - name: Item One
+    key: a
+    command: "echo one"
+  - name: Item Two
+    key: b
+    value: "two"
+  - separator: true
+  - name: "+Submenu"
+    key: s
+    menu:
+      - name: Nested
+        key: n
+        tmux: "new-window"
+`
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Verify title
+	if config.Title != "Test Menu" {
+		t.Errorf("expected title 'Test Menu', got %q", config.Title)
+	}
+
+	// Verify style
+	if config.Style.Key != "#ff0000" {
+		t.Errorf("expected style.key '#ff0000', got %q", config.Style.Key)
+	}
+	if config.Style.Border != "rounded" {
+		t.Errorf("expected style.border 'rounded', got %q", config.Style.Border)
+	}
+
+	// Verify items count (including separator)
+	if len(config.Items) != 4 {
+		t.Errorf("expected 4 items, got %d", len(config.Items))
+	}
+
+	// Verify first item
+	if config.Items[0].Name != "Item One" {
+		t.Errorf("expected first item name 'Item One', got %q", config.Items[0].Name)
+	}
+	if config.Items[0].Key != "a" {
+		t.Errorf("expected first item key 'a', got %q", config.Items[0].Key)
+	}
+	if config.Items[0].Command != "echo one" {
+		t.Errorf("expected first item command 'echo one', got %q", config.Items[0].Command)
+	}
+
+	// Verify value field
+	if config.Items[1].Value != "two" {
+		t.Errorf("expected second item value 'two', got %q", config.Items[1].Value)
+	}
+
+	// Verify separator
+	if !config.Items[2].Separator {
+		t.Error("expected third item to be separator")
+	}
+
+	// Verify submenu
+	if len(config.Items[3].Menu) != 1 {
+		t.Errorf("expected submenu with 1 item, got %d", len(config.Items[3].Menu))
+	}
+	if config.Items[3].Menu[0].Tmux != "new-window" {
+		t.Errorf("expected nested tmux 'new-window', got %q", config.Items[3].Menu[0].Tmux)
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(configPath, []byte("invalid: yaml: content: ["), 0644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestParseItems(t *testing.T) {
+	input := `a:Apple
+b:Banana
+c:Cherry:cherry-value`
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+
+	// First item: key:label
+	if items[0].Key != "a" || items[0].Name != "Apple" {
+		t.Errorf("item 0: expected key='a' name='Apple', got key=%q name=%q", items[0].Key, items[0].Name)
+	}
+	if items[0].Value != "" {
+		t.Errorf("item 0: expected empty value, got %q", items[0].Value)
+	}
+
+	// Third item: key:label:value
+	if items[2].Key != "c" || items[2].Name != "Cherry" || items[2].Value != "cherry-value" {
+		t.Errorf("item 2: expected key='c' name='Cherry' value='cherry-value', got key=%q name=%q value=%q",
+			items[2].Key, items[2].Name, items[2].Value)
+	}
+}
+
+func TestParseItems_EmptyLines(t *testing.T) {
+	input := `a:Apple
+
+b:Banana
+
+`
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items (empty lines skipped), got %d", len(items))
+	}
+}
+
+func TestParseItems_Whitespace(t *testing.T) {
+	input := "  a  :  Apple  \n  b:Banana:  spaced value  "
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	if items[0].Key != "a" || items[0].Name != "Apple" {
+		t.Errorf("whitespace not trimmed: key=%q name=%q", items[0].Key, items[0].Name)
+	}
+
+	if items[1].Value != "spaced value" {
+		t.Errorf("value whitespace not trimmed: %q", items[1].Value)
+	}
+}
+
+func TestParseItems_InvalidLines(t *testing.T) {
+	input := `valid:Item
+invalid-no-colon
+also:valid`
+
+	items := ParseItems(strings.NewReader(input))
+
+	if len(items) != 2 {
+		t.Errorf("expected 2 items (invalid line skipped), got %d", len(items))
+	}
+}

--- a/gum-keys.tmux
+++ b/gum-keys.tmux
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# gum-keys.tmux - TPM plugin entry point
+#
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$CURRENT_DIR/scripts"
+
+source "$SCRIPTS_DIR/helpers.sh"
+
+BINARY="$CURRENT_DIR/bin/gum-keys"
+GUM_KEYS_KEY=$(get_option "@gum-keys-key" "Space")
+GUM_KEYS_CONFIG=$(get_option "@gum-keys-config" "$HOME/.config/gum-keys/config.yaml")
+
+# Check if binary exists
+if [ ! -x "$BINARY" ]; then
+    tmux display-message "gum-keys: binary not found. Run 'prefix + I' to install plugins."
+    exit 0
+fi
+
+# Check if config exists, copy example if not
+if [ ! -f "$GUM_KEYS_CONFIG" ]; then
+    config_dir="$(dirname "$GUM_KEYS_CONFIG")"
+    mkdir -p "$config_dir" 2>/dev/null
+    if [ -f "$CURRENT_DIR/config.example.yaml" ]; then
+        cp "$CURRENT_DIR/config.example.yaml" "$GUM_KEYS_CONFIG"
+        tmux display-message "gum-keys: created config at $GUM_KEYS_CONFIG"
+    fi
+fi
+
+# Bind key to launcher (calculates size dynamically)
+tmux bind-key "$GUM_KEYS_KEY" run-shell "$SCRIPTS_DIR/launch.sh"

--- a/scripts/calc-size.sh
+++ b/scripts/calc-size.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# calc-size.sh - Read popup dimensions from config
+#
+
+CONFIG_PATH="${1:-$HOME/.config/gum-keys/config.yaml}"
+
+# Defaults
+WIDTH=20
+HEIGHT=12
+BORDER_PAD=2  # top + bottom border
+
+if [ -f "$CONFIG_PATH" ]; then
+    # Check if border is none
+    border=$(grep -E '^\s*border:' "$CONFIG_PATH" | head -1 | sed 's/.*border:\s*//' | tr -d ' "'"'"'')
+    [ "$border" = "none" ] && BORDER_PAD=0
+
+    # Read max_width from config
+    w=$(grep -E '^\s*max_width:' "$CONFIG_PATH" | head -1 | sed 's/.*max_width:\s*//' | tr -d ' ')
+    [ -n "$w" ] && WIDTH=$((w + 4))  # label + key + space + padding
+
+    # Read max_lines from config
+    h=$(grep -E '^\s*max_lines:' "$CONFIG_PATH" | head -1 | sed 's/.*max_lines:\s*//' | tr -d ' ')
+    [ -n "$h" ] && HEIGHT=$((h + 3 + BORDER_PAD))  # items + title(2) + buffer(1) + border
+fi
+
+echo "$WIDTH $HEIGHT"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# helpers.sh - Shared utility functions for gum-keys plugin
+#
+
+# Get a tmux option value with a default fallback
+get_option() {
+    local option="$1"
+    local default_value="$2"
+    local option_value
+
+    option_value=$(tmux show-option -gqv "$option" 2>/dev/null)
+
+    if [ -z "$option_value" ]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
+}
+
+# Get plugin directory (where the plugin is installed)
+get_plugin_dir() {
+    local script_path="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    cd "$(dirname "$script_path")/.." && pwd
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# install.sh - Build gum-keys binary
+#
+# TPM automatically runs scripts matching *install*.sh after plugin install/update.
+#
+
+set -e
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$CURRENT_DIR")"
+BIN_DIR="$PLUGIN_DIR/bin"
+BINARY="$BIN_DIR/gum-keys"
+
+echo "gum-keys: Building binary..."
+
+# Check for Go
+if ! command -v go &>/dev/null; then
+    echo "gum-keys: ERROR - Go is not installed."
+    echo "gum-keys: Install Go via: brew install go"
+    exit 1
+fi
+
+# Check Go version (require 1.21+)
+GO_VERSION=$(go version | grep -oE 'go[0-9]+\.[0-9]+' | sed 's/go//')
+GO_MAJOR=$(echo "$GO_VERSION" | cut -d. -f1)
+GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f2)
+
+if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 21 ]; }; then
+    echo "gum-keys: ERROR - Go 1.21+ required. Found: go$GO_VERSION"
+    exit 1
+fi
+
+# Create bin directory
+mkdir -p "$BIN_DIR"
+
+# Build the binary
+cd "$PLUGIN_DIR"
+go build -o "$BINARY" .
+
+if [ -x "$BINARY" ]; then
+    echo "gum-keys: Binary built at $BINARY"
+else
+    echo "gum-keys: ERROR - Build failed"
+    exit 1
+fi
+
+echo "gum-keys: Installation complete."

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# launch.sh - Calculate size and launch popup
+#
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_DIR/helpers.sh"
+
+CONFIG_PATH=$(get_option "@gum-keys-config" "$HOME/.config/gum-keys/config.yaml")
+POSITION=$(get_option "@gum-keys-position" "R,S")
+
+# Calculate dimensions
+read -r WIDTH HEIGHT < <("$CURRENT_DIR/calc-size.sh" "$CONFIG_PATH")
+
+# Parse position
+POPUP_X=$(echo "$POSITION" | cut -d',' -f1)
+POPUP_Y=$(echo "$POSITION" | cut -d',' -f2)
+[ -z "$POPUP_Y" ] && POPUP_Y="$POPUP_X"
+
+# Launch popup with calculated size
+exec tmux display-popup \
+    -E \
+    -w "$WIDTH" \
+    -h "$HEIGHT" \
+    -x "$POPUP_X" \
+    -y "$POPUP_Y" \
+    "$CURRENT_DIR/popup.sh"

--- a/scripts/popup.sh
+++ b/scripts/popup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# popup.sh - Run gum-keys in popup
+#
+
+set -e
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$CURRENT_DIR")"
+
+source "$CURRENT_DIR/helpers.sh"
+
+BINARY="$PLUGIN_DIR/bin/gum-keys"
+CONFIG_PATH=$(get_option "@gum-keys-config" "$HOME/.config/gum-keys/config.yaml")
+
+# Verify binary exists
+if [ ! -x "$BINARY" ]; then
+    echo "gum-keys: Binary not found at $BINARY"
+    echo "Run 'prefix + I' to install plugins."
+    read -n 1 -s -r -p "Press any key to close..."
+    exit 1
+fi
+
+# Verify config exists
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "gum-keys: Config not found at $CONFIG_PATH"
+    read -n 1 -s -r -p "Press any key to close..."
+    exit 1
+fi
+
+# Run gum-keys
+exec "$BINARY" --config "$CONFIG_PATH"

--- a/style.go
+++ b/style.go
@@ -18,7 +18,7 @@ func InitStyles() {
 	separatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	titleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99")).Bold(true)
 	submenuStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("222"))
-	boxStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+	boxStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 0)
 }
 
 // ApplyStyles applies config-defined style overrides
@@ -46,8 +46,10 @@ func ApplyStyles(s Style) {
 			boxStyle = boxStyle.Border(lipgloss.DoubleBorder())
 		case "thick":
 			boxStyle = boxStyle.Border(lipgloss.ThickBorder())
-		case "hidden", "none":
+		case "hidden":
 			boxStyle = boxStyle.Border(lipgloss.HiddenBorder())
+		case "none":
+			boxStyle = boxStyle.BorderStyle(lipgloss.Border{})
 		case "normal":
 			boxStyle = boxStyle.Border(lipgloss.NormalBorder())
 		}

--- a/view.go
+++ b/view.go
@@ -5,6 +5,17 @@ import (
 	"strings"
 )
 
+// truncate shortens a string to maxLen with ellipsis
+func truncate(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
 // View implements tea.Model
 func (m Model) View() string {
 	if m.quitting || (m.selected != "" && !m.transient) || m.runCommand != "" {
@@ -12,34 +23,42 @@ func (m Model) View() string {
 	}
 
 	var lines []string
+	maxWidth := m.config.Layout.MaxWidth
 
 	// Title (only at root level)
 	if m.config.Title != "" && len(m.stack) == 0 {
-		lines = append(lines, titleStyle.Render(m.config.Title))
+		title := m.config.Title
+		if maxWidth > 0 {
+			title = truncate(title, maxWidth)
+		}
+		lines = append(lines, titleStyle.Render(title))
 		lines = append(lines, "")
 	}
 
 	// Menu items
 	for _, item := range m.current {
 		if item.Separator {
-			lines = append(lines, separatorStyle.Render("  ──────────"))
+			lines = append(lines, separatorStyle.Render("────────"))
 			continue
 		}
 
 		label := item.Name
+		if maxWidth > 0 {
+			label = truncate(label, maxWidth)
+		}
 		if len(item.Menu) > 0 {
-			label = submenuStyle.Render(item.Name)
+			label = submenuStyle.Render(label)
 		}
 
-		line := fmt.Sprintf("  %s  %s", keyStyle.Render(item.Key), labelStyle.Render(label))
+		line := fmt.Sprintf("%s %s", keyStyle.Render(item.Key), labelStyle.Render(label))
 		lines = append(lines, line)
 	}
 
 	// Back hint for nested menus
 	if len(m.stack) > 0 {
 		lines = append(lines, "")
-		lines = append(lines, separatorStyle.Render("  esc: back"))
+		lines = append(lines, separatorStyle.Render("esc: back"))
 	}
 
-	return boxStyle.Render(strings.Join(lines, "\n")) + "\n"
+	return boxStyle.Render(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
## Summary
- Convert gum-keys into a TPM-compatible tmux plugin triggered by `prefix + Space`
- Add configurable popup dimensions via `layout.max_width` and `layout.max_lines` in config
- Add scripts for automatic binary installation, size calculation, and popup launching
- Support multiple border styles including "none" for seamless popup appearance

## Test plan
- [ ] Run `make install` to install plugin locally
- [ ] Press `prefix + Space` to verify popup appears
- [ ] Test submenu navigation and command execution
- [ ] Verify popup sizing adjusts based on config layout settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)